### PR TITLE
Update gulp-sass dependency for building on Windows Server 2012 R2

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-inject": "~1.3.1",
     "gulp-protractor": "~1.0.0",
     "gulp-sourcemaps": "~1.5.2",
-    "gulp-sass": "~2.0.1",
+    "gulp-sass": "~3.1.0",
     "gulp-angular-filesort": "~1.1.1",
     "main-bower-files": "~2.8.0",
     "merge-stream": "~0.1.7",


### PR DESCRIPTION
When trying to build on Windows Server 2012 R2 the "gulp styles" task does not complete and there is no indication of why not.
Same applies to the other gulp tasks which depend on the styles task.
Updating gulp-sass dependency fixes the problem for me.